### PR TITLE
Add a Global Settings page

### DIFF
--- a/lang/en/block_mmcc_retention.php
+++ b/lang/en/block_mmcc_retention.php
@@ -5,3 +5,8 @@ $string[""] = "MMCC Retention block";
 $string["mmcc_retention:addinstance"] = "Add a new MMCC Retention block";
 $string["mmcc_retention:myaddinstance"] = "Add a new MMCC Retention block to the My Moodle page";
 
+
+$string["headerconfig"] = "API Token";
+$string["descconfig"] = "";
+$string["configapitokentitle"] = "API Token";
+$string["configapitokendesc"] = "The token used to authenticate requests to MMCC's Retention Management System.";

--- a/settings.php
+++ b/settings.php
@@ -23,8 +23,16 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+$settings->add(new admin_setting_heading(
+            'headerconfig',
+            get_string('headerconfig', 'block_mmcc_retention'),
+            get_string('descconfig', 'block_mmcc_retention')
+        ));
 
-$plugin->component = 'block_mmcc_retention';     // Full name of the plugin (used for diagnostics)
-$plugin->version   = 2017021100;        // The current plugin version (Date: YYYYMMDDXX)
-$plugin->requires  = 2014111000;        // Requires this Moodle version
+$settings->add(new admin_setting_configtext(
+            'block_mmcc_retention/apitoken',
+            get_string('configapitokentitle', 'block_mmcc_retention'),
+            get_string('configapitokendesc', 'block_mmcc_retention'),
+            ""));
+
+


### PR DESCRIPTION
This settings page currently only allows the user to set the API Token used to authenticate to [MMCC's Retention Management System](https://retention.midmich.edu).

Fixes #1

For a user with active courses in the RMS:
<img width="206" alt="2017-02-10_block_mmcc_retention_with" src="https://cloud.githubusercontent.com/assets/3780536/22843594/48e32c7c-efa8-11e6-8ee1-a9d6eb1267ac.PNG">

For a user without active courses in the RMS:
<img width="202" alt="2017-02-10_block_mmcc_retention_without" src="https://cloud.githubusercontent.com/assets/3780536/22843607/53c24a74-efa8-11e6-8866-fcb20295b8bb.PNG">

If the API Token is not configured correctly, all users, even users with active courses, will see the same content (shown in the second screenshot).